### PR TITLE
Fix code block formatting.

### DIFF
--- a/doc/ci_admin_guide/Infrastructure_backups.md
+++ b/doc/ci_admin_guide/Infrastructure_backups.md
@@ -118,26 +118,18 @@ To update backup scripts perform the following steps:
 
 1. Clone `contrail-windows-ci` repository and enter `backups/` directory
 
-    ```powershell
-    PS C:\Users\user> git clone https://github.com/Juniper/contrail-windows-ci.git
-    PS C:\Users\user> cd contrail-windows-ci\backups
-    PS C:\Users\user\contrail-windows-ci\backups>
-    ```
+        PS C:\Users\user> git clone https://github.com/Juniper/contrail-windows-ci.git
+        PS C:\Users\user> cd contrail-windows-ci\backups
+        PS C:\Users\user\contrail-windows-ci\backups>
 
 1. Establish a PowerShell session with `winci-veeam` server
 
-    ```powershell
-    PS C:\Users\user\contrail-windows-ci\backups> $session = New-PSSession -ComputerName 10.84.12.29 -Credentials $(Get-Credential)
-    ```
+        PS C:\Users\user\contrail-windows-ci\backups> $session = New-PSSession -ComputerName 10.84.12.29 -Credentials $(Get-Credential)
 
 1. Copy `backups` directory's contents to `winci-veeam` server, to `C:\BackupScripts` directory
 
-    ```powershell
-    PS C:\Users\user\contrail-windows-ci\backups> Copy-Item .\* C:\BackupScripts -ToSession $session
-    ```
+        PS C:\Users\user\contrail-windows-ci\backups> Copy-Item .\* C:\BackupScripts -ToSession $session
 
 1. Close PowerShell session
 
-    ```powershell
-    PS C:\Users\user\contrail-windows-ci\backups> Remove-PSSession $session
-    ```
+        PS C:\Users\user\contrail-windows-ci\backups> Remove-PSSession $session

--- a/doc/ci_admin_guide/Merge_development_to_production.md
+++ b/doc/ci_admin_guide/Merge_development_to_production.md
@@ -27,14 +27,12 @@ Run production pipeline on `development` branch
 
 1. Update production branch (following git operations require administrative privileges on GitHub)
 
-    ```bash
-    git fetch --all --prune
-    git checkout development
-    git pull
-    git checkout production
-    git merge development
-    git push
-    ```
+        git fetch --all --prune
+        git checkout development
+        git pull
+        git checkout production
+        git merge development
+        git push
 
 2. Update Zuul configuration
 
@@ -43,14 +41,12 @@ Run production pipeline on `development` branch
 
 ### Zuul update playbook
 
-```yaml
----
-- hosts: zuul
-  remote_user: ciadmin
-  become: yes
-  roles:
-  - zuul
-```
+    ---
+    - hosts: zuul
+      remote_user: ciadmin
+      become: yes
+      roles:
+      - zuul
 
 
 ## Post checks
@@ -59,11 +55,9 @@ Run production pipeline on `development` branch
     - `zuul-merger`
     - `zuul-server`
 
-    ```bash
-    localhost $ ssh winci-zuulv2-production # with provided credentials; current address 10.84.12.75
-    systemctl status zuul-merger.service # should be active (running)
-    systemctl status zuul-server.service # should be active (running)
-    ```
+          localhost $ ssh winci-zuulv2-production # with provided credentials; current address 10.84.12.75
+          systemctl status zuul-merger.service # should be active (running)
+          systemctl status zuul-server.service # should be active (running)
 
 2. Trigger Zuul job
     - Create a dummy PR on Gerrit

--- a/doc/ci_admin_guide/Merge_development_to_production.md
+++ b/doc/ci_admin_guide/Merge_development_to_production.md
@@ -2,7 +2,6 @@
 
 This document describes the steps required to perform a merge from `development` to `production` in Contrail Windows CI.
 
-
 ## Pre-merge check
 
 Run production pipeline on `development` branch
@@ -22,7 +21,6 @@ Run production pipeline on `development` branch
         - `ZUUL_CHANGE=` (can be left empty)
         - `ZUUL_PATCHSET=` (can be left empty)
 
-
 ## Merge development to production
 
 1. Update production branch (following git operations require administrative privileges on GitHub)
@@ -38,7 +36,6 @@ Run production pipeline on `development` branch
 
     - Refer to [Update Windows CI Zuulv2][update-zuulv2] documentation
 
-
 ### Zuul update playbook
 
     ---
@@ -48,21 +45,19 @@ Run production pipeline on `development` branch
       roles:
       - zuul
 
-
 ## Post checks
 
 1. Check Zuul services:
     - `zuul-merger`
     - `zuul-server`
 
-          localhost $ ssh winci-zuulv2-production # with provided credentials; current address 10.84.12.75
-          systemctl status zuul-merger.service # should be active (running)
-          systemctl status zuul-server.service # should be active (running)
+            localhost $ ssh winci-zuulv2-production # with provided credentials; current address 10.84.12.75
+            systemctl status zuul-merger.service # should be active (running)
+            systemctl status zuul-server.service # should be active (running)
 
 2. Trigger Zuul job
     - Create a dummy PR on Gerrit
     - Post `recheck windows` on some existing PR
-
 
 ## Future considerations
 

--- a/doc/ci_admin_guide/Update_Zuul.md
+++ b/doc/ci_admin_guide/Update_Zuul.md
@@ -16,113 +16,87 @@ This procedure updates configuration using `development` or `production` branch 
 
 1.  Install required `apt` dependencies on Ansible control machine
 
-    ```bash
-    apt-get install git python3 python3-pip python3-virtualenv
-    ```
+        apt-get install git python3 python3-pip python3-virtualenv
 
 1.  Clone `contrail-windows-ci` repository
 
-    ```bash
-    cd ~/
-    git clone https://github.com/Juniper/contrail-windows-ci.git
-    cd contrail-windows-ci
-    ```
+        cd ~/
+        git clone https://github.com/Juniper/contrail-windows-ci.git
+        cd contrail-windows-ci
 
 1. Checkout branch that you want to use for configuring Zuul. For example:
 
     - to checkout `development` branch:
 
-        ```bash
-        git checkout development
-        ```
+            git checkout development
 
     - to checkout `production` branch:
 
-        ```bash
-        git fetch --all
-        git branch production origin/production
-        git checkout production
-        ```
+            git fetch --all
+            git branch production origin/production
+            git checkout production
 
-1.  Verify that `development` (or `production`) branch contains PRs with required changes to Zuul configuration
+1. Verify that `development` (or `production`) branch contains PRs with required changes to Zuul configuration
 
     - Assuming `PR#2` and `PR#1` are required PRs, run the following command:
 
-    ```bash
-    git log --oneline
-    ```
+            git log --oneline
 
     - Output will contain a list of merged PRs, from newest to oldest. Required PRs should be at the top:
 
-    ```
-    abcdabc PR#2
-    abcd123 PR#1
-    e8691f5 Some other PR
-    3af841e Some other PR, part 2
-    # ... omitted
-    ```
+            abcdabc PR#2
+            abcd123 PR#1
+            e8691f5 Some other PR
+            3af841e Some other PR, part 2
+            # ... omitted
 
     **Example**
 
     - Assume that [add contrail-infra-doc to gerrit (#212)](https://github.com/Juniper/contrail-windows-ci/pull/212) is a latest PR that was merged and this change has to be applied on Zuul
     - Then output of `git log` should look like this:
 
-    ```
-    93c783b add contrail-infra-doc to gerrit (#212)
-    1f86f26 zuul: setup-zuul-server playbook; variables in prod inventory (#210)
-    # ... omitted
-    ```
+            93c783b add contrail-infra-doc to gerrit (#212)
+            1f86f26 zuul: setup-zuul-server playbook; variables in prod inventory (#210)
+            # ... omitted
 
-1.  Move to `ansible` directory
+1. Move to `ansible` directory
 
-    ```bash
-    cd ansible
-    ```
+        cd ansible
 
-1.  Create a virtualenv and install `pip` dependencies
+1. Create a virtualenv and install `pip` dependencies
 
-    ```bash
-    python3 -m virtualenv -p /usr/bin/python3 venv
-    source venv/bin/activate
-    pip install -r python-requirements.txt
-    ```
+        python3 -m virtualenv -p /usr/bin/python3 venv
+        source venv/bin/activate
+        pip install -r python-requirements.txt
 
-1.  Create a file for Ansible vault key and populate it with the key
+1. Create a file for Ansible vault key and populate it with the key
 
-    ```bash
-    touch ~/ansible-vault-key
-    vim ~/ansible-vault-key  # enter ansible vault key into a file
-    ```
+        touch ~/ansible-vault-key
+        vim ~/ansible-vault-key  # enter ansible vault key into a file
 
-1.  Test connection to Zuul with Ansible
+1. Test connection to Zuul with Ansible
 
-    ```bash
-    ansible -i inventory.prod --private-key=YOUR_PRIVATE_KEY zuul -m ping
-    ```
+        ansible -i inventory.prod --private-key=YOUR_PRIVATE_KEY zuul -m ping
 
     - where `YOUR_PRIVATE_KEY` is a path to your SSH private key
 
-1.  Run `setup-zuul-server.yml` playbook
+1. Run `setup-zuul-server.yml` playbook
 
-    ```bash
-    ansible-playbook -i inventory.prod --private-key=YOUR_PRIVATE_KEY setup-zuul-server.yml
-    ```
+        ansible-playbook -i inventory.prod --private-key=YOUR_PRIVATE_KEY setup-zuul-server.yml
 
     Verify that the run completed successfully.
     The output should be following and `failed` task count must equal zero.
 
-    ```
-    #
-    # task list omitted for brevity
-    #
-
-    PLAY RECAP ******************************************************************************************
-    10.84.12.75                : ok=22   changed=2    unreachable=0    failed=0
-
-    #
-    # ... - task run time omitted for brevity
-    #
-    ```
+        #
+        # task list omitted for brevity
+        #
+        
+        PLAY RECAP    ********************************************************************************   **********
+        10.84.12.75                : ok=22   changed=2    unreachable=0    failed=0
+        
+        #
+        # ... - task run time omitted for brevity
+        #
 
     - `failed` task count should be equal to zero
 

--- a/doc/ci_admin_guide/Update_private_docker_registry.md
+++ b/doc/ci_admin_guide/Update_private_docker_registry.md
@@ -19,21 +19,15 @@ The update of local docker registry is required when the version of Controller u
 4. If there is no such script:
     - download it from [here](https://github.com/Juniper/contrail-windows-ci/tree/development/utility/update_docker_registry):
 
-        ```
-        curl https://raw.githubusercontent.com/Juniper/contrail-windows-ci/development/utility/update_docker_registry/update-docker-registry.py --output update-docker-registry.py
-        ```
+            curl https://raw.githubusercontent.com/Juniper/contrail-windows-ci/development/utility/update_docker_registry/update-docker-registry.py --output update-docker-registry.py
 
     - make it executable:
 
-        ```
-        chmod +x ./update-docker-registry.py
-        ```
+            chmod +x ./update-docker-registry.py
 
 5. Run the script with Contrail version tag as parameter, for example:
 
-    ```
-    ./update-docker-registry.py ocata-master-206
-    ```
+        ./update-docker-registry.py ocata-master-206
 
 6. If new version of Contrail Ansible Deployer uses more images than listed in `update-docker-registry.py` script:
     - update images list in the script locally,
@@ -49,38 +43,26 @@ New version of Contrail Ansible Deployer may also use some new Openstack images.
 
 2. Set the name of required image in local variable (replace `<IMAGE-NAME>` with proper value:
 
-    ```
-    image_name=<IMAGE-NAME>
-    ```
+        image_name=<IMAGE-NAME>
 
 3. Pull the image:
 
-    ```
-    docker image pull ci-repo.englab.juniper.net:5000/kolla/${image_name}:ocata
-    ```
+        docker image pull ci-repo.englab.juniper.net:5000/kolla/${image_name}:ocata
 
 4. Get the Image ID of previously pulled image:
 
-    ```
-    image_id=$(docker image ls | grep kolla | grep ${image_name} | awk '{ print $3 }' | uniq)
-    ```
+        image_id=$(docker image ls | grep kolla | grep ${image_name} | awk '{ print $3 }' | uniq)
 
     - verify the ID:
 
-        ```
-        echo "$image_id"
-        ```
+            echo "$image_id"
 
 5. Tag the image:
 
-    ```
-    docker tag ${image_id} localhost:5000/kolla/${image_name}:ocata
-    ```
+        docker tag ${image_id} localhost:5000/kolla/${image_name}:ocata
 
 6. Push the image to local repository:
 
-    ```
-    docker push localhost:5000/kolla/${image_name}:ocata
-    ```
+        docker push localhost:5000/kolla/${image_name}:ocata
 
 7. Repeat steps 2-6 for all other required images.

--- a/doc/contrail_deployment/contrail_deployment_manual.md
+++ b/doc/contrail_deployment/contrail_deployment_manual.md
@@ -6,16 +6,17 @@
 * Machine for running Ansible playbooks (Linux or Windows with WSL)
 ## Steps
 - On each of the Windows hosts:
-    ```powershell
-    Invoke-WebRequest https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile ConfigureRemotingForAnsible.ps1
-    .\ConfigureRemotingForAnsible.ps1 -DisableBasicAuth -EnableCredSSP -ForceNewSSLCert -SkipNetworkProfileCheck
-    ```
+
+        Invoke-WebRequest https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile ConfigureRemotingForAnsible.ps1
+
+        .\ConfigureRemotingForAnsible.ps1 -DisableBasicAuth -EnableCredSSP -ForceNewSSLCert -SkipNetworkProfileCheck
+
 * On the Ansible machine:
-    ```bash
-    git clone git@github.com:Juniper/contrail-ansible-deployer.git
-    cd contrail-ansible-deployer
-    vim config/instances.yaml
-    ```
+
+        git clone git@github.com:Juniper/contrail-ansible-deployer.git
+        cd contrail-ansible-deployer
+        vim config/instances.yaml
+
     * Refer to examples:
         * `config/instances.yaml.bms_win_example` if you have already deployed controller and you only want windows compute nodes
         * `config/instances.yaml.bms_win_full_example` if you want to deploy controller and windows compute nodes together
@@ -31,10 +32,10 @@
             * Add openstack-* roles to the controller node and set `CLOUD_ORCHESTRATOR` to `openstack`
             * Fill keystone credentials and kolla config. Check `config/instances.yaml.openstack_example`
     * Proceed with running Ansible playbooks:
-        ```bash
-        sudo -H ansible-playbook -e orchestrator=openstack -i inventory/ playbooks/configure_instances.yml
-        sudo -H ansible-playbook -i inventory playbooks/install_openstack.yml
-        sudo -H ansible-playbook -e orchestrator=openstack -i inventory/ playbooks/install_contrail.yml
-        ```
+
+            sudo -H ansible-playbook -e orchestrator=openstack -i inventory/ playbooks/configure_instances.yml
+            sudo -H ansible-playbook -i inventory playbooks/install_openstack.yml
+            sudo -H ansible-playbook -e orchestrator=openstack -i inventory/ playbooks/install_contrail.yml
+
 ## Testing the new setup
 Refer to [this document](../user_guide/connection_scenarios.md)

--- a/doc/user_guide/connection_scenarios.md
+++ b/doc/user_guide/connection_scenarios.md
@@ -4,116 +4,118 @@
 
 * Via Contrail WebUI:
     1. Create a policy with the following rule:
-        ```
-        pass protocol any network any ports any <> network any ports any
-        ```
+
+           pass protocol any network any ports any <> network any ports any
+
     1. Create virtual network called `testnet1` with single subnet: `10.0.1.0/24`. Leave every field as default except IP pool (set it to be from `10.0.1.10` to `10.0.1.100`) and network policy (set it to policy created in first step).
     1. Create virtual network called `testnet2` with single subnet: `10.0.2.0/24`. Leave every field as default except IP pool (set it to be from `10.0.2.10` to `10.0.2.100`) and network policy (set it to policy created in first step).
 
 * On both Windows VMs:
     1. Verify if Agent service is running:
-        ```powershell
-        Get-Service ContrailAgent
-        ```
+
+            Get-Service ContrailAgent
+
         State should be Running
+
     1. Verify if VMSwitch Extension is running and enabled:
-        ```powershell
-        Get-VMSwitch -Name "Layered*" | Get-VMSwitchExtension
-        ```
+
+            Get-VMSwitch -Name "Layered*" | Get-VMSwitchExtension
+
         Find block of data describing to `vRouter`  
         Both Enabled and Running fields should be True
+
     1. Verify if Docker Driver service is running:
-        ```powershell
-        Get-Service contrail-docker-driver
-        ```
+
+            Get-Service contrail-docker-driver
+
         State should be Running
     1. Create docker network `testnet1` on the 1st Windows compute code:
-        ```powershell
-        docker network create --ipam-driver windows -d Contrail --opt tenant=admin --opt network=testnet1 testnet1
-        ```
+
+            docker network create --ipam-driver windows -d Contrail --opt tenant=admin --opt network=testnet1 testnet1
+
     1. Run a docker container in the prepared network on the 1st Windows compute node:
-        ```powershell
-        docker run -id --network testnet1 --name container1 microsoft/windowsservercore powershell
-        ```
+
+            docker run -id --network testnet1 --name container1 microsoft/windowsservercore powershell
+
     1. Inspect container1 on the 1st Windows compute node. Find the part that describes endpoints and verify that it has a correct IP address assigned (from the previously configured IP pool).
-        ```powershell
-        docker inspect container1
-        ```
+
+            docker inspect container1
+
     1. Run interactive shell inside the container1 on the 1st Windows compute node:
-        ```powershell
-        docker exec -it container1 powershell
-        ```
+
+            docker exec -it container1 powershell
+
     1. Create docker network ‘testnet2’ on the 2nd Windows compute node:
-        ```powershell
-        docker network create --ipam-driver windows -d Contrail --opt tenant=admin --opt network=testnet2 testnet2
-        ```
+
+            docker network create --ipam-driver windows -d Contrail --opt tenant=admin --opt network=testnet2 testnet2
+
     1. Run a docker container in the prepared network (‘testnet2’) on the 2nd Windows compute node:
-        ```powershell
-        docker run -id --network testnet2 --name container2 microsoft/windowsservercore powershell
-        ```
+
+            docker run -id --network testnet2 --name container2 microsoft/windowsservercore powershell
+
     1. Inspect container2 on 2nd Windows compute node. Find the part that describes endpoints and verify that it has a correct IP address assigned (from the previously configured IP pool).
-        ```powershell
-        docker inspect container2
-        ```
+
+            docker inspect container2
+
     1. Run a 2nd docker container in the prepared network (‘testnet2’) on the 2nd Windows compute node:
-        ```powershell
-        docker run -id --network testnet2 --name container3 microsoft/iis powershell
-        ```
+
+            docker run -id --network testnet2 --name container3 microsoft/iis powershell
+
     1. Inspect container3 on the 2nd Windows compute node. Find the part that describes endpoints and verify that it has a correct IP address assigned (from the previously configured IP pool).
-        ```powershell
-        docker inspect container3
-        ```
+
+            docker inspect container3
+
     1. Run interactive shell inside the container2 on the 2nd Windows compute node:
-        ```powershell
-        docker exec -it container2 powershell
-        ```
+
+            docker exec -it container2 powershell
+
     1. Run interactive shell inside the container3 on the 2nd Windows compute node. Remember that Powershell console that has been used in previous step is now running a session in container2. To operate on a host system, open new Powershell console.
-        ```powershell
-        docker exec -it container3 powershell
-        ```
+
+            docker exec -it container3 powershell
+
 
 ## ICMP
 1. Verify that ICMP protocol works within single virtual network.  
     To do that invoke the following Powershell command in interactive session of container2 (on the 2nd Windows compute Node):
-    ```powershell
-    ping <IP address of container3>
-    ```
+
+        ping <IP address of container3>
+
 1. Verify that ICMP protocol works across virtual network boundaries.  
     To do that invoke the following Powershell command in interactive session of container1 (on the 1st Windows Compute Node):
-    ```powershell
-    ping <IP address of container2>
-    ```
+
+        ping <IP address of container2>
+
 ## TCP
 1. Invoke the following commands in container3’s interactive session (on the 2nd Windows Compute Node):
-    ```powershell
-    cd \inetpub\wwwroot
-    echo "We come in peace." >> index.html
-    ```
+
+        cd \inetpub\wwwroot
+        echo "We come in peace." >> index.html
+
 1. Invoke the following command in container1’s interactive session (on the 1st Windows Compute Node). Verify that you receive server response with webpage prepared in previous step.
-    ```powershell
-    Invoke-WebRequest http://<container3's IP address> -UseBasicParsing
-    ```
+
+        Invoke-WebRequest http://<container3's IP address> -UseBasicParsing
+
 ## UDP
 1. Set up UDP listener on container3 (on the 2nd Windows Compute Node).  
     To do that invoke the following commands in container3’s interactive console. Last instruction is a blocking call waiting for incoming packet.
-    ```powershell
-    $RemoteIPEndpoint = New-Object System.Net.IPEndPoint([IPAddress]::Any, 0)
-    $UDPRcvSocket = New-Object System.Net.Sockets.UdpClient 3000
-    $Payload = $UDPRcvSocket.Receive([ref]$RemoteIPEndpoint)
-    ```
+
+        $RemoteIPEndpoint = New-Object System.Net.IPEndPoint([IPAddress]::Any, 0)
+        $UDPRcvSocket = New-Object System.Net.Sockets.UdpClient 3000
+        $Payload = $UDPRcvSocket.Receive([ref]$RemoteIPEndpoint)
+
 1. Send UDP packet from container1 (on the 1st Windows Compute Node).  
     To do that invoke the following commands in container1’s interactive console.
-    ```powershell
-    $ListenerAddress = New-Object System.Net.IPEndPoint([IPAddress]::Parse("10.0.2.4"), 3000)
-    $UDPSenderSocket = New-Object System.Net.Sockets.UdpClient 0
-    $Payload = [Text.Encoding]::UTF8.GetBytes("We come in peace.")
-    $UDPSenderSocket.Send($Payload, $Payload.Length, $ListenerAddress)
-    ```
+
+        $ListenerAddress = New-Object System.Net.IPEndPoint([IPAddress]::Parse("10.0.2.4"), 3000)
+        $UDPSenderSocket = New-Object System.Net.Sockets.UdpClient 0
+        $Payload = [Text.Encoding]::UTF8.GetBytes("We come in peace.")
+        $UDPSenderSocket.Send($Payload, $Payload.Length, $ListenerAddress)
+
 1. When packet is received by container3, blocking call to `System.Net.Sockets.UdpClient.Receive` (in container3 on the 2nd Windows Compute Node) is going to return. If that doesn’t happen immediately, repeat invocation of `$UDPSenderSocket.Send` (in container1 on the 1st Windows Compute Node).
 1. Invoke the following command in container1’s interactive session to display payload of received UDP packet to verify that it’s consisted with sent message:
-    ```powershell
+
     [Text.Encoding]::UTF8.GetString($Payload)
-    ```
+
 ## Network policies and security groups
 1. Create additional policies and security groups (through WebUI) with various settings and demonstrate that they affect communication between networks. One may follow ICMP/TCP/UDP test procedures with various policies and security groups.
 1. Revert network configuration (policies and security groups) to its original state not to affect other experiments.
@@ -123,29 +125,28 @@
 1. Assign Floating IP created in second step to port (`Ports` tab) that belongs to container2.
 1. Assign Floating IP created in second step to port (`Ports` tab) that belongs to container3.
 1. Set up an UDP listener on container2. Enter the following Powershell instructions in interactive console of container2 on the 2nd Windows Compute Node:
-    ```powershell
-    $Sock = [System.Net.Sockets.UdpClient]::new(5000)
-    $Endpoint = [System.Net.IPEndPoint]::new([IPAddress]::Any, 5000)
-    while ($True) {
-        $Data = $Sock.Receive([ref]$Endpoint)
-        Write-Host "Received packet from $Endpoint"
-    }
-    ```
+
+        $Sock = [System.Net.Sockets.UdpClient]::new(5000)
+        $Endpoint = [System.Net.IPEndPoint]::new([IPAddress]::Any, 5000)
+        while ($True) {
+            $Data = $Sock.Receive([ref]$Endpoint)
+            Write-Host "Received packet from $Endpoint"
+        }
+
 1. Set up an UDP listener on container3. Enter the following Powershell instructions in interactive console of container3 on the 2nd Windows Compute Node:
-    ```powershell
-    $Sock = [System.Net.Sockets.UdpClient]::new(5000)
-    $Endpoint = [System.Net.IPEndPoint]::new([IPAddress]::Any, 5000)
-    while ($True) {
-        $Data = $Sock.Receive([ref]$Endpoint)
-        Write-Host "Received packet from $Endpoint"
-    }
-    ```
+
+        $Sock = [System.Net.Sockets.UdpClient]::new(5000)
+        $Endpoint = [System.Net.IPEndPoint]::new([IPAddress]::Any, 5000)
+        while ($True) {
+            $Data = $Sock.Receive([ref]$Endpoint)
+            Write-Host "Received packet from $Endpoint"
+        }
+
 1. Send multiple UDP packets from container1 on the 1st Windows Compute Node. Use different source ports. Set the floating IP (created in step 2) as destination address. Use 5000 (as used in step 6) as destination port.  
     Then verify that some packets were received by container2 while some other packets were received by container3. Receiving container is going to display a message: `Received packet from <sender address>`.  
     Use the following Powershell command to send 10 UDP packets from various source ports:
-    ```powershell
-    1..100 | % {
-        $s = [System.Net.Sockets.UdpClient]::new(10000+$_)
-        $s.Send("C".ToCharArray(), 1, "10.0.2.101", 5000)
-    }
-    ```
+
+        1..100 | % {
+            $s = [System.Net.Sockets.UdpClient]::new(10000+$_)
+            $s.Send("C".ToCharArray(), 1, "10.0.2.101", 5000)
+        }


### PR DESCRIPTION
MKdocs uses a plugin for parsing triple backtick notation of code blocks: https://python-markdown.github.io/extensions/fenced_code_blocks/

The pluging unfortunately doesn't parse indented triple backtick codeblocks. It's recognized as bug. https://github.com/mkdocs/mkdocs/issues/282
https://github.com/Python-Markdown/markdown/issues/53

This is problematic when we want to put a code block in a list without breaking it (which breaks the automatic numbering of list points).

The triple backtick notation is actually a github convention. Even though many other processors actually use it as well.

Normally in markdown, code blocks are identified by the right number of spaces before them.

The workaround is to fail back on the "true" space-based code block notation in problematic places. (turns out that the number of spaces it's pretty much always a multiple of 4, based on the list level).