### PR TITLE
Added information about noauth mode deployment to docs

### DIFF
--- a/doc/contrail_deployment/CAD_for_windows_design.md
+++ b/doc/contrail_deployment/CAD_for_windows_design.md
@@ -10,12 +10,13 @@ This is a document describing initial support of deploying Windows compute nodes
   * Thus, these roles are divided into `*_Linux` and `*_Win32NT` for usage in c-a-d for Linux and c-a-d for Windows respectively.
 
 ## Orchestrators:
-  * OpenStack must be specified as an orchestrator, because Keystone is required by Windows Docker driver for authorization.
+  * OpenStack has to be specified as an orchestrator if Keystone is to be used as an authentication service in controller.
+  * No orchestrator must be specified if no authentication service should be used in controller.
 
 ## Playbooks:
   * `provision_instances.yml` - not supported at this moment.
   * `configure_instances.yml`
-  * `install_openstack.yml`
+  * `install_openstack.yml` - if needed (see install_openstack paragraph)
   * `install_contrail.yml`
 
 ## configure_instances:
@@ -39,8 +40,10 @@ This is a document describing initial support of deploying Windows compute nodes
     To do that, Windows Test-Signing Mode must be enabled and reboot is done to apply the change.
 
 ## install_openstack:
+  * Must be used only if Keystone is to serve as an authentication service.
+  * Controller might be deployed in "noauth" mode and in that case this playbook shouldn't be run.
+  * For now, whole OpenStack is deployed for single purpose of using Keystone. In the future, setting up Keystone should be extracted to separate role and only this role should be specified instead of whole install_openstack playbook.
   * There are no changes to this playbook.
-  * Whole OpenStack is installed for now, but in the future there should have to specify only the role in `config/instances.yaml` which is responsible for installing Keystone.
 
 ## install_contrail:
   * Specific dlls must be present in main Windows system directory (`C:/Windows/System32`) for the software to run.

--- a/doc/contrail_deployment/contrail_deployment_manual.md
+++ b/doc/contrail_deployment/contrail_deployment_manual.md
@@ -19,6 +19,7 @@
     * Refer to examples:
         * `config/instances.yaml.bms_win_example` if you have already deployed controller and you only want windows compute nodes
         * `config/instances.yaml.bms_win_full_example` if you want to deploy controller and windows compute nodes together
+        * `config/instances.yaml.bms_win_no_openstack_example` if you want to deploy controller without OpenStack and windows compute nodes together
     * More precise explanation of the required fields:
         * For Windows computes use `bms_win` dict instead of regular `bms`
         * Roles supported on Windows are `vrouter` and `win_docker_driver` - specify them
@@ -27,20 +28,21 @@
         * Set `WINDOWS_DEBUG_DLLS_PATH` to path on Ansible machine containing MSVC 2015 debug dlls, specifically: `msvcp140d.dll`, `ucrtbased.dll` and `vcruntime140d.dll`
     * To deploy a controller for windows compute nodes:
         * Configure as it would be a controller node for a linux ecosystem
-        * For now docker driver on windows needs keystone set up on controller:
+        * If you wish to use keystone as authentication service on controller:
             * Add openstack-* roles to the controller node and set `CLOUD_ORCHESTRATOR` to `openstack`
             * Fill keystone credentials and kolla config. Check `config/instances.yaml.openstack_example`
     * Proceed with running Ansible playbooks:
-        * If you have already deployed the controller:
+        * If you have already deployed the controller **or** if you want to deploy controller without OpenStack (noauth mode):
 
                 sudo -H ansible-playbook -i inventory/ playbooks/configure_instances.yml
                 sudo -H ansible-playbook -i inventory/ playbooks/install_contrail.yml
 
-        * If you don't have the controller:
+        * If you want to deploy controller with OpenStack:
 
                 sudo -H ansible-playbook -e orchestrator=openstack -i inventory/ playbooks/configure_instances.yml
                 sudo -H ansible-playbook -i inventory playbooks/install_openstack.yml
                 sudo -H ansible-playbook -e orchestrator=openstack -i inventory/ playbooks/install_contrail.yml
+
 
 ## Testing the new setup
 Refer to [this document](../user_guide/connection_scenarios.md)


### PR DESCRIPTION
Contrail-ansible-deployer might be used to set up environment
in "noauth" mode (without Openstack, specifically Keysotne).
Docs should reflect that.