### PR TITLE
Fix link to docker registry provisioning doc

### DIFF
--- a/doc/ci_admin_guide/List_of_VMs_in_Windows_CI.md
+++ b/doc/ci_admin_guide/List_of_VMs_in_Windows_CI.md
@@ -136,3 +136,4 @@
     * Refer to [Infrastructure Backups][backups]
 
 [backups]: https://github.com/Juniper/contrail-windows-docs/blob/master/doc/ci_admin_guide/Infrastructure_backups.md
+[docker-registry-provisioning]: Docker_registry_provisioning.md


### PR DESCRIPTION
Sidenote: we can also consider adding `strict: true` to `mkdocs.yml` to deny broken links. Although this has some problems:
* It immediately quits `mkdocs serve`, so you have to manually restart it (perhaps it's a feature?)
* It wouldn't detect the bug from this PR anyway (because the link wasn't broken, it was nonexistent)