### PR TITLE
Use tags and disable autostart of jenkins agent when updating slaves

### DIFF
--- a/doc/ci_admin_guide/Update_Jenkins_slaves.md
+++ b/doc/ci_admin_guide/Update_Jenkins_slaves.md
@@ -49,7 +49,7 @@ The upgrade procedure consists of:
             Set-Service jenkins_swarm_client -StartupType Manual
             ```
 
-        1. __NOTE__: Auto start of `jenkins_swarm_client` after a reboot removes the `Mark this node as temporarily offline` status from the slave.
+        1. __NOTE__: `jenkins_swarm_client` must be disabled, since a reboot removes the `Mark this node as temporarily offline` status from the slave. After the update procedure completes, you should re-enable this service to reconnect the builder to Jenkins.
         1. Add a tag to every task that needs to be executed.
     1. Prepare inventory file.
         1. Edit file `inventory.devel/groups`.

--- a/doc/ci_admin_guide/Update_Jenkins_slaves.md
+++ b/doc/ci_admin_guide/Update_Jenkins_slaves.md
@@ -39,9 +39,17 @@ The upgrade procedure consists of:
 
     1. Checkout `github.com/Juniper/contrail-windows-ci` repository.
     1. Enter `ansible/` directory.
-    1. Prepare your environment by going through steps described in `README.md`. 
+    1. Prepare your environment by going through steps described in `README.md`.
     1. Find the ansible role that is responsible for the upgrade.
-        1. Modify the role to suit your needs. 
+        1. Modify the role to suit your needs.
+        1. If modification could cause a slave restart, manually disable auto start of `jenkins_swarm_client`:
+
+            ```powershell
+            Stop-Service jenkins_swarm_client
+            Set-Service jenkins_swarm_client -StartupType Manual
+            ```
+
+        1. __NOTE__: Auto start of `jenkins_swarm_client` after a reboot removes the `Mark this node as temporarily offline` status from the slave.
         1. Add a tag to every task that needs to be executed.
     1. Prepare inventory file.
         1. Edit file `inventory.devel/groups`.
@@ -49,7 +57,11 @@ The upgrade procedure consists of:
     1. Create one-off playbook.
         1. Create an yml file in the root of `ansible/` dir.
         1. Specify hosts and roles to be executed.
-    1. Run the playbook, specifying ansible vault, the inventory and prepared playbook.
+    1. Run the playbook, specifying:
+        - ansible vault key location,
+        - inventory,
+        - task tags to execute,
+        - prepared playbook.
 1. Test if the change worked.
     1. Remote into the machine and verify if change was successful.
     1. Test if job passes.
@@ -58,6 +70,12 @@ The upgrade procedure consists of:
             1. In its Jenksinfile, replace tags of nodes that you removed on t he node with the temporary tag.
             1. Open the pull request with "do not merge" in the title.
             1. Wait for CI to be triggered normally. Wait for it to pass.
+    1. If autostart of `jenkins_swarm_client` was disabled:
+
+        ```powershell
+        Set-Service jenkins_swarm_client -StartupType Automatic
+        Start-Service jenkins_swarm_client
+        ```
 
     > NOTE: the following steps may change depending on case-by-case basic.
 


### PR DESCRIPTION
- Use tags when launching `ansible-playbook` for updating slaves.
- Disable autostart if applied changes would reboot a host.